### PR TITLE
Add META.json

### DIFF
--- a/META.json
+++ b/META.json
@@ -1,0 +1,39 @@
+{
+   "resources" : {
+      "repository" : "http://github.com/bricas/math-base36",
+      "license" : "http://dev.perl.org/licenses/"
+   },
+   "distribution_type" : "module",
+   "version" : "0.14",
+   "author" : [
+      "Rune Henssel <perl@henssel.dk>"
+   ],
+   "build_requires" : {
+      "ExtUtils::MakeMaker" : 6.59,
+      "Test::More" : 0,
+      "Test::Exception" : 0
+   },
+   "abstract" : "Encoding and decoding of base36 strings",
+   "configure_requires" : {
+      "ExtUtils::MakeMaker" : 6.59
+   },
+   "no_index" : {
+      "directory" : [
+         "inc",
+         "t"
+      ]
+   },
+   "dynamic_config" : 1,
+   "meta-spec" : {
+      "url" : "http://module-build.sourceforge.net/META-spec-v1.4.html",
+      "version" : 1.4
+   },
+   "license" : "perl",
+   "name" : "Math-Base36",
+   "requires" : {
+      "Math::BigInt" : "1.60",
+      "perl" : "5.6.0"
+   },
+   "generated_by" : "Module::Install version 1.19 using Module::Install::JSONMETA version 7.001"
+}
+


### PR DESCRIPTION
This PR is a submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/april.html).  (link not ready yet, hopefully soon when Neil updates the site.)

This adds a `META.json` as generated via [JSON::CPAN::Meta](https://metacpan.org/JSON::CPAN::Meta).  See @neilb's [blog](http://neilb.org/2017/05/16/missing-metadata-files.html) for further information.

In lieu of this PR, I recommend moving from Module::Install to another CPAN authoring tool such as [Dist::Zilla](https://metacpan.org/pod/Dist::Zilla) or [Minilla](https://metacpan.org/pod/Minilla) which can manage CPAN metadata for you; also especially as perl-5.26 now removes `.` from `@INC` (seen in [RT](https://rt.cpan.org/Public/Bug/Display.html?id=121170)).